### PR TITLE
cli.py: add --questions argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,15 @@ groq-qa
 # Output results in JSON format:
 groq-qa --json 
 
- # Run with model, temperature, and json overrides:
-groq-qa --model llama3-70b-8192 --temperature 0.9 --json
+ # Run with model, temperature, questions, and json overrides:
+groq-qa --model llama3-70b-8192 --temperature 0.9 --questions 1 --json
+
 ```
 
 #### CLI Options:
 * `--model`: The default model to be used for generating QA pairs is defined in `config.json`. The default is set to `llama3-70b-8192`.
-* `--temperature`: Controls the randomness of the model's output. Lower values like `0.1` will result in more deterministic and focused outputs, while higher values will make the output more random. The default is set to `0.1`.
+* `--temperature`: Controls the randomness of the model's output. Lower values will result in more deterministic and focused outputs, while higher values will make the output more random. The default is set to `0.1`.
+* `--questions`: Allows you to specify the exact number of question-answer pairs to generate per chunk of text. For example, using `1` will force the system to generate 1 QA pair for each chunk, regardless of chunk size or token limits.
 * `--json`: If this flag is included, the output will be saved in a JSON format. By default, the output is stored as a plain text file. The default is set to `False`.
 
 ## 🛠 Configuration

--- a/src/groq_qa_generator/config.py
+++ b/src/groq_qa_generator/config.py
@@ -70,6 +70,13 @@ def parse_arguments():
             help="Set the temperature for the model's output generation. Must be between 0.0 and 1.0.",
         )
 
+        parser.add_argument(
+            "--questions",
+            type=int,
+            default=None,
+            help="Number of QA pairs per text chunk to generate.",
+        )
+
         # Parse the arguments
         args = parser.parse_args()
 
@@ -180,16 +187,19 @@ def load_config(args, config_file="config.json"):
         Raises:
             KeyError: If any expected keys for CLI arguments are missing in the config dictionary.
         """
-        if args.model:
-            config["model"] = args.model
-        if args.temperature is not None:
-            config["temperature"] = args.temperature
+        # Set model and temperature if provided, otherwise keep existing config
+        config["model"] = args.model or config.get("model", "default_model")
+        config["temperature"] = args.temperature if args.temperature is not None else config.get("temperature", 0.1)
+
+        # Set questions with a default value of None if not provided
+        config["questions"] = args.questions or None
+
+        # Set JSON output handling, modifying the output file if JSON is selected
         if args.json:
             base_output_file = os.path.splitext(config["output_file"])[0]
             config["output_file"] = f"{base_output_file}.json"
-            config["json"] = args.json
-        else:
-            config["json"] = False
+        config["json"] = args.json or False
+
 
     try:
         config = load_json_config(config_file)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,7 @@
 import json
 import pytest
 from unittest.mock import mock_open, patch
-from groq_qa_generator.config import parse_arguments, load_config
+from groq_qa_generator.config import parse_arguments
 
 
 def test_parse_arguments_default(monkeypatch):
@@ -29,5 +29,40 @@ def test_parse_arguments_json_flag(monkeypatch):
     )  # Simulate running with '--json'
     args = parse_arguments()
     assert args.json is True
+
+def test_parse_arguments_with_questions(monkeypatch):
+    """
+    Test that the --questions argument is correctly parsed when using the 'groq-qa' command.
+
+    This test ensures that when the --questions argument is provided via the 'groq-qa' command
+    line, it is correctly parsed by the parse_arguments function and stored in the args object.
+
+    The test uses the `monkeypatch` fixture to mock the command-line arguments as if
+    the script is executed with 'groq-qa --questions 1'.
+
+    Steps:
+    1. Mock the command-line input to simulate running 'groq-qa --questions 1'.
+    2. Call the parse_arguments() function to simulate argument parsing.
+    3. Assert that args.questions is equal to 1.
+
+    Input:
+        Command-line args: ["groq-qa", "--questions", "1"]
+
+    Expected output:
+        args.questions == 1
+
+    Edge cases considered:
+    - The --questions argument is correctly parsed as an integer.
+    """
+    # Mock the sys.argv to simulate the command-line input for 'groq-qa'
+    monkeypatch.setattr("sys.argv", ["groq-qa", "--questions", "1"])
+    
+    # Parse the arguments
+    args = parse_arguments()
+    
+    # Check that the questions argument is correctly parsed
+    assert args.questions == 1
+
+
 
 

--- a/tests/test_qa_generation.py
+++ b/tests/test_qa_generation.py
@@ -5,6 +5,7 @@ from groq_qa_generator.qa_generation import (
     load_sample_question,
     load_system_prompt,
     create_groq_prompt,
+    generate_qa_pairs
 )
 
 
@@ -26,11 +27,13 @@ def test_load_sample_question():
 
 
 def test_load_system_prompt():
-    """Test loading and preparing the system prompt.
+    """Test loading and preparing the system prompt with and without --questions.
 
     This test verifies that the load_system_prompt function reads the system
     prompt from a file and replaces the "<n>" placeholder with the correct
-    number of questions based on the provided chunk size and tokens per question.
+    number of questions based on either:
+    1. The provided chunk size and tokens per question, or
+    2. The explicit --questions argument.
 
     It ensures that the returned prompt contains the expected format and
     structure after processing.
@@ -38,13 +41,26 @@ def test_load_system_prompt():
     system_prompt_content = "Generate <n> questions based on the text."
     chunk_size = 512
     tokens_per_question = 60
-    expected_prompt = "Generate 8 questions based on the text."
 
+    # Case 1: No --questions argument, default calculation (chunk_size / tokens_per_question)
+    expected_prompt_default = "Generate 8 questions based on the text."
     with patch("builtins.open", mock_open(read_data=system_prompt_content)):
-        result = load_system_prompt(
+        result_default = load_system_prompt(
             "system_prompt.txt", chunk_size, tokens_per_question
         )
-    assert result == expected_prompt
+    assert result_default == expected_prompt_default
+
+    # Case 2: Explicit --questions argument (e.g., --questions 5)
+    questions_arg = 5
+    expected_prompt_with_questions = "Generate 5 questions based on the text."
+    with patch("builtins.open", mock_open(read_data=system_prompt_content)):
+        result_with_questions = load_system_prompt(
+            "system_prompt.txt",
+            chunk_size,
+            tokens_per_question,
+            questions=questions_arg,
+        )
+    assert result_with_questions == expected_prompt_with_questions
 
 
 def test_create_groq_prompt():
@@ -62,3 +78,4 @@ def test_create_groq_prompt():
 
     result = create_groq_prompt(system_prompt, sample_question)
     assert result == expected_full_prompt
+


### PR DESCRIPTION
- Introduced the `--questions` argument to the CLI to allow users to specify the number of questions generated per chunk of text.
- Updated the `load_system_prompt` function to handle both user-provided and default-calculated numbers of questions.
- Adjusted `generate_qa_pairs` to properly pass the `questions` argument from the configuration.
- Added corresponding tests to ensure correct behavior when `--questions` is provided or omitted.